### PR TITLE
Update 'bom' to use repo name as key 'jboss-bom'

### DIFF
--- a/_config/guide_metadata.yml
+++ b/_config/guide_metadata.yml
@@ -32,7 +32,7 @@ migration:
   prefix: /migrations/seam2
   version: 1.0.0.Final
   github_org: seam
-bom:
+jboss-bom:
   prefix: /stack/jboss-bom
   title: JBoss BOMs
   index_label: BOMs Index


### PR DESCRIPTION
> Warning: Not tested. Patch based on reading code and assumptions on use. :)

The Key is used as module name and later used to reconstruct the github URL for source downloads.

"Get the Source" Action button here links to a non existing repository. The backing metadata use 'bom' as name and not 'jboss-bom' which is the correct. (Could as a alternative override the repo name in github-metadata instead of the key, not sure if the key is used elsewhere)
http://www.jboss.org/jdf/stage/stack/jboss-bom/jboss-javaee-6.0-with-tools/
