### PR TITLE
JDF-173 Fix for whitespace wrapping for pre & monospace tags

### DIFF
--- a/stylesheets/partials/_asciidoc.scss
+++ b/stylesheets/partials/_asciidoc.scss
@@ -63,7 +63,7 @@
   }
   
   span.monospaced, pre {
-    white-space: pre;
+    white-space: pre-wrap;
     word-wrap: normal;
     word-break: normal;
   }


### PR DESCRIPTION
This should fix the issue described in JDF-173. Tested on FF and Chrome. "whitespace:pre-wrap" is probably the safest of all whitespace rules in CSS. It forces wrapping of content while retaining new-lines and whitespace.

Ref: http://css-tricks.com/almanac/properties/w/whitespace/
