### PR TITLE
Lock Bootstrap-sass to 2.3.2.2 for now

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@
 source "https://rubygems.org"
 
 gem 'awestruct', '0.5.3'
-gem 'bootstrap-sass'
+gem 'bootstrap-sass', "~> 2.3.2.2"
 gem 'rdiscount', '~> 2.0.7', :platforms => [:ruby]
 gem 'htmlcompressor'
 gem 'coffee-script'


### PR DESCRIPTION
Bootstrap-sass 3.0.0 was released on Oct 31. Locking the current version in the gemfile to 2.3.2 to ensure that the build doesn't break.
