### PR TITLE
BZ1030455 Fixed narrow width for documentation text.

### DIFF
--- a/stylesheets/documentation.css
+++ b/stylesheets/documentation.css
@@ -15,7 +15,7 @@ body, table {
 
 body {
   height: 100%;
-  width: 560px;
+  width: 95%;
   position: relative;
   float: left;
   z-index: 2;
@@ -23,6 +23,10 @@ body {
 
 table {
   border-collapse: collapse;
+  margin: 0 1em;
+  table-layout: fixed;
+  white-space: pre-wrap;
+  word-wrap: break-word;
 }
 
 p {


### PR DESCRIPTION
Set the body width to 95% to allow padding. And set table margins to 1em to pad tables further. Added rules to set fixed-layout for tables and allow word-wrap.
